### PR TITLE
Pinned ndcube version number, for now

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     h5py>=2.9
     astropy>=3.1
     sunpy>=1.1.1
-    ndcube>=1.2
+    ndcube==1.4.2
     parfive>=1.5
     python-dateutil>=2.8
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     matplotlib>=3.1
     h5py>=2.9
     astropy>=3.1
-    sunpy>=1.1.1
+    sunpy<3.1
     ndcube==1.4.2
     parfive>=1.5
     python-dateutil>=2.8


### PR DESCRIPTION
Unfortunately, ndcube 2.0 (just released _today_, 2021-10-29) contains API breaking changes that are causing issues for eispac. For now, we are just pinning ndcube to version 1.4.2 while we update our code. 