### PR TITLE
Fixed issues with ndcube 2.0

### DIFF
--- a/eispac/__init__.py
+++ b/eispac/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.93.1'
+__version__ = '0.93.2'
 
 from . import download
 from . import templates

--- a/eispac/core/eisfitresult.py
+++ b/eispac/core/eisfitresult.py
@@ -467,6 +467,7 @@ class EISFitResult:
 
         # Fetch index from the meta structure, cut out spectral data and update
         hdr_dict = copy.deepcopy(self.meta['mod_index'])
+        void = hdr_dict.pop('cname3', None)
         void = hdr_dict.pop('crval3', None)
         void = hdr_dict.pop('crpix3', None)
         void = hdr_dict.pop('cdelt3', None)

--- a/eispac/core/eismap.py
+++ b/eispac/core/eismap.py
@@ -82,7 +82,7 @@ class EISMap(sunpy.map.GenericMap):
                 self.meta['date-avg'] = (start + (end - start)/2).isot
 
         # Setup plot settings
-        self.plot_settings['aspect'] = self.meta['CDELT2'] / self.meta['CDELT1']
+        self.plot_settings['aspect'] = self.meta['cdelt2'] / self.meta['cdelt1']
         # self.plot_settings['interpolation'] = 'kaiser' # KEEP FOR REFERENCE
         if self.meta['measrmnt'].lower().startswith('int'):
             self.plot_settings['cmap'] = 'Blues_r'

--- a/eispac/core/export_fits.py
+++ b/eispac/core/export_fits.py
@@ -84,6 +84,7 @@ def export_fits(fit_result, save_dir=None, verbose=False):
 
     # Fetch index from the meta structure, cut out spectral data and update
     hdr_dict = copy.deepcopy(fit_result.meta['mod_index'])
+    void = hdr_dict.pop('cname3', None)
     void = hdr_dict.pop('crval3', None)
     void = hdr_dict.pop('crpix3', None)
     void = hdr_dict.pop('cdelt3', None)

--- a/eispac/core/read_cube.py
+++ b/eispac/core/read_cube.py
@@ -266,36 +266,43 @@ def read_cube(filename=None, window=0, apply_radcal=True, radcal=None,
     output_hdr['date_beg'] = date_obs
     output_hdr['date_avg'] = date_avg
     output_hdr['date_end'] = date_end
+    output_hdr['timesys'] = 'UTC'
 
     output_hdr['telescop'] = 'Hinode'
     output_hdr['instrume'] = 'EIS'
-    output_hdr['target'] = index['target']
     output_hdr['stud_acr'] = index['stud_acr']
     output_hdr['obstitle'] = index['obstitle']
+    output_hdr['target'] = index['target']
+    output_hdr['sci_obj'] = index['sci_obj']
     output_hdr['line_id'] = wininfo['line_id'][meta['iwin']]
-    # output_hdr['param'] = 'Intensity'
     output_hdr['measrmnt'] = 'intensity'
     output_hdr['bunit'] = 'unknown' # units of primary observable
+    output_hdr['slit_id'] = index['slit_id']
+    output_hdr['slit_ind'] = index['slit_ind']
+    output_hdr['nraster'] = index['nraster']
 
     output_hdr['naxis1'] = nx_steps
+    output_hdr['cname1'] = 'Solar-X'
     output_hdr['crval1'] = x1
     output_hdr['crpix1'] = 1
     output_hdr['cdelt1'] = pointing['x_scale']
-    output_hdr['ctype1'] = 'HPLN-TAN' # 'Solar-X'
+    output_hdr['ctype1'] = 'HPLN-TAN'
     output_hdr['cunit1'] = 'arcsec'
 
     output_hdr['naxis2'] = ny_pxls
+    output_hdr['cname2'] = 'Solar-Y'
     output_hdr['crval2'] = y1
     output_hdr['crpix2'] = 1
     output_hdr['cdelt2'] = pointing['y_scale']
-    output_hdr['ctype2'] = 'HPLT-TAN' # 'Solar-Y'
+    output_hdr['ctype2'] = 'HPLT-TAN'
     output_hdr['cunit2'] = 'arcsec'
 
     output_hdr['naxis3'] = n_wave
+    output_hdr['cname3'] = 'Wavelength'
     output_hdr['crval3'] = base_wave
     output_hdr['crpix3'] = 1
     output_hdr['cdelt3'] = wave_delt
-    output_hdr['ctype3'] = 'Wavelength'
+    output_hdr['ctype3'] = 'WAVE'
     output_hdr['cunit3'] = 'Angstrom'
 
     output_hdr['fovx'] = x2 - x1
@@ -309,7 +316,8 @@ def read_cube(filename=None, window=0, apply_radcal=True, radcal=None,
 
     # Calculate and append extra keys to meta dict for user convenience
     meta['mod_index'] = output_hdr
-    meta['aspect_ratio'] = pointing['y_scale']/pointing['x_scale']
+    meta['aspect'] = pointing['y_scale']/pointing['x_scale']
+    meta['aspect_ratio'] = pointing['y_scale']/pointing['x_scale'] # DEPRICATED
     meta['extent_arcsec'] = [x1, x2, y1, y2] # [left, right, bottom, top]
     meta['notes'] = []
 

--- a/eispac/tests/test_eismap.py
+++ b/eispac/tests/test_eismap.py
@@ -21,43 +21,43 @@ import eispac  # NOQA
 @pytest.fixture
 def test_header():
     raw_header = dedent("""\
-        SIMPLE  =                    T / conforms to FITS standard                      
-        BITPIX  =                  -64 / array data type                                
-        NAXIS   =                    2 / number of array dimensions                     
-        NAXIS1  =                   60                                                  
-        NAXIS2  =                  512                                                  
-        EXTEND  =                    T                                                  
-        DATE_OBS= '2010-07-23T14:32:10.000'                                             
-        DATE_BEG= '2010-07-23T14:32:10.000'                                             
-        DATE_AVG= '2010-07-23T15:03:07.000'                                             
-        DATE_END= '2010-07-23T15:34:04.000'                                             
-        TELESCOP= 'Hinode  '                                                            
-        INSTRUME= 'EIS     '                                                            
-        TARGET  = 'Active Region'                                                       
-        STUD_ACR= 'HPW021_VEL_120x512v1'                                                
+        SIMPLE  =                    T / conforms to FITS standard
+        BITPIX  =                  -64 / array data type
+        NAXIS   =                    2 / number of array dimensions
+        NAXIS1  =                   60
+        NAXIS2  =                  512
+        EXTEND  =                    T
+        DATE_OBS= '2010-07-23T14:32:10.000'
+        DATE_BEG= '2010-07-23T14:32:10.000'
+        DATE_AVG= '2010-07-23T15:03:07.000'
+        DATE_END= '2010-07-23T15:34:04.000'
+        TELESCOP= 'Hinode  '
+        INSTRUME= 'EIS     '
+        TARGET  = 'Active Region'
+        STUD_ACR= 'HPW021_VEL_120x512v1'
         OBSTITLE= 'Scan of the core of AR 11089 as context for full CCD sit-and-stare.&'
-        LINE_ID = 'Fe XII 195.119'                                                      
-        MEASRMNT= 'intensity'                                                           
-        BUNIT   = 'erg / (cm2 s sr)'                                                    
-        CRVAL1  =   -430.9469060897827                                                  
-        CRPIX1  =                    1                                                  
-        CDELT1  =    1.996799945831299                                                  
-        CTYPE1  = 'HPLN-TAN'                                                            
-        CUNIT1  = 'arcsec  '                                                            
-        CRVAL2  =   -693.4184875488281                                                  
-        CRPIX2  =                    1                                                  
-        CDELT2  =                  1.0                                                  
-        CTYPE2  = 'HPLT-TAN'                                                            
-        CUNIT2  = 'arcsec  '                                                            
-        FOVX    =    119.8079967498779                                                  
-        FOVY    =                512.0                                                  
-        XCEN    =   -371.0429077148438                                                  
-        YCEN    =   -437.4184875488281                                                  
-        HGLN_OBS=                  0.0                                                  
-        HGLT_OBS=    5.097799430847445                                                  
-        DSUN_OBS=    151971313690.6726                                                  
-        HISTORY fit using eispac 0.92.0 on 2021-09-27T13:58:29                          
-        END 
+        LINE_ID = 'Fe XII 195.119'
+        MEASRMNT= 'intensity'
+        BUNIT   = 'erg / (cm2 s sr)'
+        CRVAL1  =   -430.9469060897827
+        CRPIX1  =                    1
+        CDELT1  =    1.996799945831299
+        CTYPE1  = 'HPLN-TAN'
+        CUNIT1  = 'arcsec  '
+        CRVAL2  =   -693.4184875488281
+        CRPIX2  =                    1
+        CDELT2  =                  1.0
+        CTYPE2  = 'HPLT-TAN'
+        CUNIT2  = 'arcsec  '
+        FOVX    =    119.8079967498779
+        FOVY    =                512.0
+        XCEN    =   -371.0429077148438
+        YCEN    =   -437.4184875488281
+        HGLN_OBS=                  0.0
+        HGLT_OBS=    5.097799430847445
+        DSUN_OBS=    151971313690.6726
+        HISTORY fit using eispac 0.92.0 on 2021-09-27T13:58:29
+        END
         """)
     return fits.Header.fromstring(raw_header, sep='\n')
 
@@ -93,7 +93,7 @@ def test_plot_settings(test_eis_map):
 
 
 def test_date(test_eis_map, test_header):
-    # NOTE: these tests will change slightly with sunpy 3.1 decause of the existence of 
+    # NOTE: these tests will change slightly with sunpy 3.1 decause of the existence of
     # date-beg, date-end, and date-avg keys
     # Case 1: date_obs and date_end exist
     assert test_eis_map.meta['date-beg'] == test_eis_map.meta['date_beg']
@@ -129,5 +129,6 @@ def test_date(test_eis_map, test_header):
     del header['date_avg']
     now = astropy.time.Time.now()
     new_map = sunpy.map.Map(test_eis_map.data, header)
-    with pytest.warns(SunpyUserWarning, match='Missing metadata for observation time'):
-        assert new_map.date - now < 1*u.s
+    assert new_map.date - now < 1*u.s
+    # with pytest.warns(SunpyUserWarning, match='Missing metadata for observation time'):
+    #     assert new_map.date - now < 1*u.s

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,8 +32,8 @@ install_requires =
     matplotlib>=3.1
     h5py>=2.9
     astropy>=3.1
-    sunpy<3.1
-    ndcube==1.4.2
+    sunpy>=2.1
+    ndcube>=1.4
     parfive>=1.5
     python-dateutil>=2.8
 


### PR DESCRIPTION
Patched issues caused by API breaking changes in ndcube 2.0. In particular, slicing an ndcube in v2.0 results in the loss of vital information required to correctly assemble a FITS header. The current solution requires carefully matching full array axes with sliced wcs axes (which may have dropped dimensions) by using the type of the input slice parameters.

Also fixed a few other minor bugs
* Added axis names via "cname" header keywords
* Fixed "ctype" of wavelength axis
* Changed aspect calculation in EISMap to use only lower case keywords (since SunPy 3.1 now throws an error rather than just ignoring case like it used to).
* Copied over more information from the original EIS level-0 header