### PR TITLE
Fixed bug with reading unicode characters from output files

### DIFF
--- a/eispac/core/read_fit.py
+++ b/eispac/core/read_fit.py
@@ -58,7 +58,12 @@ def walk_and_load(hdf5_file, hdf5_path, verbose=False):
         if (isinstance(output.dtype, np.bytes_) or str(output.dtype) == 'object'
             or str(output.dtype).startswith('S', 1)):
             # Convert objects, byte or ascii strings to uncode
-            output = output.astype(np.unicode_) # strings to unicode
+            try:
+                # Old method, for consistency
+                output = output.astype(np.unicode_) # strings to unicode
+            except:
+                # Better handling of unicode characters
+                output = np.array(output.item().decode('utf-8'))
         if output.size == 1:
             # Extract value from a single-element array (0- or 1-D arrays only)
             output = output.item()


### PR DESCRIPTION
Output HDF5 files with Unicode characters in internal filepath strings would sometimes fail to load with eispac.read_fit(). Added fallback method of decoding strings that patches the issue.