### PR TITLE
Added data mirrors to eis_catalog GUI and eis_download_files CLI

### DIFF
--- a/eispac/download/download_db.py
+++ b/eispac/download/download_db.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 import parfive
 
-def download_db(download_dir=None):
+def download_db(download_dir=None, source='nrl'):
     """Download the offical EIS as-run SQLite database
 
     Parameters
@@ -31,7 +31,10 @@ def download_db(download_dir=None):
     # if os.path.isfile(local_filepath):
     #     os.remove(local_filepath)
 
-    remote_filepath = 'https://hesperia.gsfc.nasa.gov/ssw/hinode/eis/database/catalog/eis_cat.sqlite'
+    if source.lower().startswith('nrl'):
+        remote_filepath = 'https://eis.nrl.navy.mil/level1/db/eis_cat.sqlite'
+    else:
+        remote_filepath = 'https://hesperia.gsfc.nasa.gov/ssw/hinode/eis/database/catalog/eis_cat.sqlite'
 
     print(f' + downloading eis_cat.sqlite')
     print(f'   remote: {remote_filepath}')

--- a/eispac/download/download_hdf5_data.py
+++ b/eispac/download/download_hdf5_data.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import asyncio
 import parfive
 # import urllib.request, requests, wget
 
@@ -34,10 +35,15 @@ class download_hdf5_data:
 
     """
 
-    def __init__(self, filename=None, local_top='data_eis', datetree=False,
+    def __init__(self, filename=None, source='nrl', local_top='data_eis', datetree=False,
                  nodata=False, nohead=False, overwrite=False, headonly=False,
                  max_conn=2):
-        self.top_url = 'https://eis.nrl.navy.mil/level1/hdf5/'
+        if source.lower().startswith('nasa'):
+            self.top_url = 'https://umbra.nascom.nasa.gov/hinode/eis/level1/hdf5/'
+        elif source.lower().startswith('mssl'):
+            self.top_url = 'https://vsolar.mssl.ucl.ac.uk/eispac/hdf5/'
+        else:
+            self.top_url = 'https://eis.nrl.navy.mil/level1/hdf5/'
         self.local_top = local_top
         self.datetree = datetree
         self.nodata = nodata
@@ -118,6 +124,9 @@ class download_hdf5_data:
         """
         Use parfive to download the file
         """
+        # Quick hack for silencing ignored exceptions on windows due to outdated parfive code
+        if os.name == 'nt':
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
         local_filepath = os.path.join(local_dir, local_name)
         # check that local directory exists and create as needed
         self.check_local_dir(local_filepath)

--- a/scripts/eis_download_files.py
+++ b/scripts/eis_download_files.py
@@ -70,6 +70,18 @@ def eis_download_files():
         datetree = True
         arglist.remove('-datetree')
 
+    # look for remote source options
+    data_source = 'nrl'
+    if '-nasa' in arglist:
+        data_source = 'nasa'
+        arglist.remove('-nasa')
+    if '-mssl' in arglist:
+        data_source = 'mssl'
+        arglist.remove('-mssl')
+    if '-nrl' in arglist:
+        data_source = 'nrl'
+        arglist.remove('-nrl')
+
     # loop over inputs
     for file in arglist:
         # parse the input
@@ -85,7 +97,8 @@ def eis_download_files():
         # download the files
         for name in names:
             print(f'+ processing {name}')
-            o = eispac.download.download_hdf5_data(name, datetree=datetree)
+            o = eispac.download.download_hdf5_data(name, source=data_source,
+                                                   datetree=datetree)
 
 if __name__ == '__main__':
     eis_download_files()


### PR DESCRIPTION
* The `eis_catalog` GUI tools now has options for selecting the remote data source. The new options are:
   * NASA (https://umbra.nascom.nasa.gov/hinode/eis/level1/hdf5/)
   * MSSL (https://vsolar.mssl.ucl.ac.uk/eispac/hdf5/)
* Also added a data mirror for the EIS as-run database (NRL)
* Updated the `eis_download_files` command line script with optional flags of "-nrl", "-nasa", and "-mssl" that can be used to select the data source