### PR TITLE
catalog and template bugfix

### DIFF
--- a/eispac/core/match_templates.py
+++ b/eispac/core/match_templates.py
@@ -52,7 +52,7 @@ def match_templates(eis_obs):
     #       or "s__11_188_675.3c.template.h5"
     for t in range(num_templates):
         line_id_str = all_templates[t].name.split('.')[0]
-        line_id_str.replace('__', '_') # single character elements are padded
+        line_id_str = line_id_str.replace('__', '_') # single character elements are padded
         line_id_parts = line_id_str.split('_')
         template_waves[t] = float(line_id_parts[2]+'.'+line_id_parts[3])
 


### PR DESCRIPTION
A few small bugfixes
* Fixed `eis_catalog` GUI to also find triggered rasters that were missing from the `eis_main` sqlite table. Side note: most triggered rasters (e.g. "FlareResponse01" triggered by the "FlareHunter" study) are incorrectly assigned a "study_id" of either 1 or 8. As such, some of the metadata (such as "study_acr", "obstitle" and "target") are incorrect.
* Patched an issue with `match_templates` sometimes failing to find templates with a single character element in the filename.
* Removed support for Qt4 in the `eis_catalog` GUI (it is now past the end-of-life support in Python). 