### PR TITLE
Prioritize `date_start` when defining WCS and coordinate frame

### DIFF
--- a/eispac/core/eismap.py
+++ b/eispac/core/eismap.py
@@ -126,13 +126,20 @@ class EISMap(sunpy.map.GenericMap):
         return self._get_date('date_avg') or super().date_average
 
     @property
-    def date(self):
-        # NOTE: we override this property to prioritize date_average 
-        # over DATE-OBS (or DATE_OBS). In GenericMap, this is reversed.
-        # We do this because we want to make sure we are constructing our 
-        # coordinate frames from DATE_AVG (the midpoint of the raster) and 
-        # not DATE-OBS which is the beginning of the raster.
-        return self.date_average or super().date
+    def reference_date(self):
+        """
+        The reference date for the coordinate system
+
+        According to Section 2.4 of
+        `EIS Software Note 9 <https://solarb.mssl.ucl.ac.uk/SolarB/eis_docs/eis_notes/09_POINTING/eis_swnote_09.pdf>`_,
+        the pointing keywords are defined at the start of the raster. As such, this property returns the
+        time at the beginning of the raster.
+
+        .. note:: This property is overridden because `sunpy.map.GenericMap` sets
+                  this to be the ``.date_average`` which in this case is the midpoint
+                  of the raster.
+        """
+        return self.date_start
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):

--- a/eispac/tests/test_eismap.py
+++ b/eispac/tests/test_eismap.py
@@ -116,7 +116,7 @@ def test_date_is_date_start(test_eis_map):
 
 def test_reference_date_is_date_start(test_eis_map):
     "Test that the reference date is the time at the beginning of the raster"
-    assert test_eis_map.reference_date == test_eis_map.date_start
+    assert test_eis_map.reference_date == test_eis_map.date_start == Time(test_eis_map.wcs.dateavg)
 
 
 def test_plot_settings(test_eis_map):

--- a/eispac/tests/test_eismap.py
+++ b/eispac/tests/test_eismap.py
@@ -104,30 +104,19 @@ def test_date_props(test_eis_map, attr, key):
     assert getattr(test_eis_map, attr).isot == test_eis_map.meta[key]
 
 
-def test_date(test_eis_map, test_header):
-    # Case 1: date-average exists
-    assert test_eis_map.date.isot == test_eis_map.meta['date_avg']
-    # Case 2: date-average is None so default to date_obs
-    header = copy.deepcopy(test_header)
-    del header['date_beg']
-    del header['date_end']
-    del header['date_avg']
-    new_map = sunpy.map.Map(test_eis_map.data, header)
-    assert new_map.date.isot == new_map.meta['date_obs']
-    # Case 3: date_avg is None so default to date_start
-    header = copy.deepcopy(test_header)
-    del header['date_avg']
-    del header['date_end']
-    del header['date_obs']
-    new_map = sunpy.map.Map(test_eis_map.data, header)
-    assert new_map.date.isot == new_map.meta['date_beg']
-    # Case 4: date_end and date_avg do not exist
-    header = copy.deepcopy(test_header)
-    del header['date_avg']
-    del header['date_beg']
-    del header['date_obs']
-    new_map = sunpy.map.Map(test_eis_map.data, header)
-    assert new_map.date.isot == new_map.meta['date_end']
+def test_date_is_dateobs(test_eis_map):
+    "Test that .date returns DATE_OBS"
+    assert test_eis_map.date.isot == test_eis_map.meta['date_obs']
+
+
+def test_date_is_date_start(test_eis_map):
+    "Test that .date returns the same date as .date_start"
+    assert test_eis_map.date == test_eis_map.date_start
+
+
+def test_reference_date_is_date_start(test_eis_map):
+    "Test that the reference date is the time at the beginning of the raster"
+    assert test_eis_map.reference_date == test_eis_map.date_start
 
 
 def test_plot_settings(test_eis_map):

--- a/eispac/tests/test_eismap.py
+++ b/eispac/tests/test_eismap.py
@@ -1,7 +1,6 @@
 """
 Tests for `eispac.EISMap`
 """
-import copy
 from textwrap import dedent
 
 import numpy as np
@@ -116,7 +115,7 @@ def test_date_is_date_start(test_eis_map):
 
 def test_reference_date_is_date_start(test_eis_map):
     "Test that the reference date is the time at the beginning of the raster"
-    assert test_eis_map.reference_date == test_eis_map.date_start == Time(test_eis_map.wcs.dateavg)
+    assert test_eis_map.reference_date == test_eis_map.date_start
 
 
 def test_plot_settings(test_eis_map):


### PR DESCRIPTION
As pointed out by @yjzhu-solar, in [EIS SW Note 9, Section 2.4](https://solarb.mssl.ucl.ac.uk/SolarB/eis_docs/eis_notes/09_POINTING/eis_swnote_09.pdf), it states that,

> The FITS headers, however, do not include the time of each exposure, and thus the pointing keywords should be tied to a time that is also provided in the header. The best time to use is the one contained in the DATE OBS keyword, the start time of the raster. This means that all the pointing data in the FITS headers need to be positions at that time.

Previously, `EISMap` was overriding `.date` in order to prioritize `date_average`, the midpoint of the raster, clearly in contrast to the above statement about how the pointing keywords are defined. As such, this PR does two things:

1. Removes the overriding of `.date`. Now, `EISMap.date` will fall back to that in `sunpy.map.GenericMap` which will prioritize `DATE-OBS` and `DATE-BEG` before `DATE-AVG`.
2. Adds a `reference_date` property which always prioritizes `date_start`. (see below for rationale of why this was added).

This fix is somewhat complicated by the fact that date handling in `sunpy` was recently overhauled (see sunpy/sunpy#7682 for more information). However, with these fixes, `EISMap` should still use the correct date in both current and future versions of sunpy:

- In versions prior to sunpy v6 (i.e. 5.1.x and below), `.date` is used to to define the WCS as well as coordinate frame. As such, with this PR, `.date_start` will now be used to define the WCS and coordinate frame.
- In version 6.0 of sunpy and beyond, `.reference_date` is used to define the coordinate frame. Additionally, on the WCS, the ``dateavg`` property is set to to `.reference_date` such that the start date of the raster is appropriately prioritized.

I've also adjusted and simplified the tests for the date handling in `EISMap` as most of that testing is now covered in `GenericMap` anyway. 

Regarding the definitions of the EIS pointing keywords, two questions:

1. That SW note is rather old. Is this all still true?
2. That SW pertains to the full raster files. Does it still hold for the FITS files that are produced after fitting? I'm not sure why it wouldn't be, but figured I would ask the question.