### PR TITLE
Adding more metadata to fits files and EISMap

### DIFF
--- a/eispac/core/eiscube.py
+++ b/eispac/core/eiscube.py
@@ -4,6 +4,7 @@ import sys
 import copy
 import numpy as np
 import astropy.units as u
+from astropy.nddata import StdDevUncertainty
 from astropy.convolution import convolve, CustomKernel
 from astropy.coordinates import SkyCoord
 from ndcube import __version__ as ndcube_ver
@@ -228,7 +229,7 @@ class EISCube(NDCube):
                 new_radcal = new_radcal/self.radcal
 
         new_data = self.data.copy()*new_radcal
-        new_errs = self.uncertainty.array.copy()*new_radcal
+        new_errs = StdDevUncertainty(self.uncertainty.array.copy()*new_radcal)
         new_meta = copy.deepcopy(self.meta)
         new_meta['mod_index']['bunit'] = 'erg / (cm2 s sr)'
         new_meta['notes'].append('Applied radcal to convert photon counts to intensity')
@@ -260,7 +261,7 @@ class EISCube(NDCube):
             return self
 
         new_data = self.data.copy()/self.radcal
-        new_errs = self.uncertainty.array.copy()/self.radcal
+        new_errs = StdDevUncertainty(self.uncertainty.array.copy()/self.radcal)
         new_meta = copy.deepcopy(self.meta)
         new_meta['mod_index']['bunit'] = 'photon'
         new_meta['notes'].append('Removed radcal to convert intensity to photon counts')
@@ -471,6 +472,7 @@ class EISCube(NDCube):
         if self.uncertainty is not None:
             sm_errs = np.sqrt(convolve(self.uncertainty.array**2,
                                        sm_kernel, **kwargs))
+            sm_errs = StdDevUncertainty(sm_errs)
         else:
             sm_errs = None
         sm_data_mask = np.logical_or(np.isnan(sm_data), sm_data < 0)

--- a/eispac/tests/test_eismap.py
+++ b/eispac/tests/test_eismap.py
@@ -36,6 +36,7 @@ def test_header():
         LINE_ID = 'Fe XII 195.119'
         MEASRMNT= 'intensity'
         BUNIT   = 'erg / (cm2 s sr)'
+        NRASTER =                   60
         CRVAL1  =   -430.9469060897827
         CRPIX1  =                    1
         CDELT1  =    1.996799945831299
@@ -82,7 +83,7 @@ def test_nickname(test_eis_map):
 
 
 def test_processing_level(test_eis_map):
-    assert test_eis_map.processing_level == 3
+    assert test_eis_map.processing_level == 2
 
 
 def test_spatial_units(test_eis_map):
@@ -124,3 +125,19 @@ def test_plot_settings(test_eis_map):
     assert isinstance(test_eis_map.plot_settings['norm'].stretch, AsinhStretch)
     scale = test_eis_map.scale.axis2 / test_eis_map.scale.axis1
     assert test_eis_map.plot_settings['aspect'] == scale.decompose().value
+
+
+def test_duration(test_eis_map):
+    assert test_eis_map.duration == 61.9*u.min
+
+
+def test_step_date_obs(test_eis_map):
+    assert test_eis_map._step_date_obs is None
+    assert len(test_eis_map.step_date_obs) == test_eis_map.meta['naxis1']
+    assert test_eis_map.step_date_obs[-1].isot == test_eis_map.meta['date_obs']
+
+
+def test_step_exptime(test_eis_map):
+    assert test_eis_map._step_exptime is None
+    assert len(test_eis_map.step_exptime) == test_eis_map.meta['naxis1']
+    assert test_eis_map.step_exptime[0] == 61.9


### PR DESCRIPTION
Copied additional header keywords to the `EISCube.meta['mod_index']`. This will automatically propagate the metadata out to any output "fits" file or `EISMap`

Short list of keywords added:
* "tr_mode" (Hinode tracking mode)
* "SAA" (IN / OUT South Atlantic Anomaly)
* "HLZ" (IN / OUT High-Latitude Zone)
* "exptime" and "cadence" (avg values for all raster steps)
* "tl_id", "jop_id", "study_id", "rast_id" (EIS specific id numbers)

Also set the uncertainty types of `EISCube` and `EISMap` objects to `StdDevUncertainty`, since AstroPy still lacks a proper class for measured uncertainties, and added default data masks. (closes #55 and closes #84, respectively)

Furthermore, all new fits files created with `export_fits` will now include extra binary tables with the exact observation and exposure time for each raster step (i.e. slit position along the x-axis). Like uncertainties, these arrays are only read when the fits file is loaded directly with `eispac.EISMap`. The arrays can be accessed with `EISMap.step_date_obs` and `EISMap.step_exptime`. Loading the files with `sunpy.map.Map` (of just loading older output fits files) will yield estimated times based on `date_obs` and `date_end`.

Lastly, added copies of the date keywords to all new fits files with the "_" characters replaced with "-". This gives full compliance with the FITS-4 standard while maintaining the customary keywords used in solar physics and the Hinode mission. (closes #100)
