### PR TITLE
Bugfix for integer slicing of an EISCube

### DIFF
--- a/eispac/core/eiscube.py
+++ b/eispac/core/eiscube.py
@@ -169,10 +169,13 @@ class EISCube(NDCube):
         slice_str = '['
         for i, sl_obj in enumerate(item):
             delim = '' if i == 0 else ', '
-            start = '' if sl_obj.start is None else str(sl_obj.start)
-            stop = '' if sl_obj.stop is None else str(sl_obj.stop)
-            step = '' if sl_obj.step is None else ':'+str(sl_obj.step)
-            slice_str = slice_str + delim + start + ':' + stop + step
+            if isinstance(sl_obj, int):
+                slice_str = slice_str + delim +str(sl_obj)
+            else:
+                start = '' if sl_obj.start is None else str(sl_obj.start)
+                stop = '' if sl_obj.stop is None else str(sl_obj.stop)
+                step = '' if sl_obj.step is None else ':'+str(sl_obj.step)
+                slice_str = slice_str + delim + start + ':' + stop + step
         slice_str = slice_str + ']'
         kwargs['meta']['notes'].append(f'Sliced with EISCube{slice_str}')
 

--- a/eispac/tests/test_read_cube.py
+++ b/eispac/tests/test_read_cube.py
@@ -34,3 +34,28 @@ def test_total_intensity(test_data_filepath):
     eis_cube = eispac.read_cube(test_data_filepath, 192.394)
     sum_inten = eis_cube.sum_spectra()
     assert isinstance(sum_inten, NDCube)
+
+def test_slice_box(test_data_filepath):
+    eis_cube = eispac.read_cube(test_data_filepath, 192.394)
+    slice_cube = eis_cube[0:10,0:10,:]
+    assert isinstance(slice_cube, NDCube)
+
+def test_slice_step(test_data_filepath):
+    eis_cube = eispac.read_cube(test_data_filepath, 192.394)
+    slice_cube = eis_cube[:,1,:]
+    assert isinstance(slice_cube, NDCube)
+
+def test_slice_point(test_data_filepath):
+    eis_cube = eispac.read_cube(test_data_filepath, 192.394)
+    slice_cube = eis_cube[1,1,:]
+    assert isinstance(slice_cube, NDCube)
+
+def test_extract_pix(test_data_filepath):
+    eis_cube = eispac.read_cube(test_data_filepath, 192.394)
+    point_cube = eis_cube.extract_points([[0,0], [1,1]], units='pixel')
+    assert isinstance(point_cube, NDCube)
+
+def test_extract_arcsec(test_data_filepath):
+    eis_cube = eispac.read_cube(test_data_filepath, 192.394)
+    point_cube = eis_cube.extract_points([[0,-200], [20,-160]], units='arcsec')
+    assert isinstance(point_cube, NDCube)


### PR DESCRIPTION
Small bugfix for slicing an `EISCube` using single integer values (e.g. "[1,1,:]"). Fixes #117 

Also added more tests for `EISCube` slicing and the new `.extract_points()` method.

