### PR TITLE
Fixes for catalog handling and time parsing

### DIFF
--- a/eispac/data/templates/__init__.py
+++ b/eispac/data/templates/__init__.py
@@ -38,4 +38,4 @@ def fit_template_filenames():
     Return a list of all available fitting template files.
     """
     rootdir = pathlib.Path(os.path.dirname(eispac.__file__)) / "data" / "templates"
-    return list(rootdir.glob('*.template.h5'))
+    return sorted(list(rootdir.glob('*.template.h5')))

--- a/eispac/util/convert.py
+++ b/eispac/util/convert.py
@@ -2,14 +2,32 @@
 
 __all__ = ['tai2utc', 'utc2tai']
 
-import datetime
+import sys
+from datetime import datetime
 from astropy.time import Time
 from dateutil.parser import parse
 
 epoch_diff = 694656000.0
 
 def tai2utc(tai):
-    """Convert TAI (in sec from midnight 1958 Jan 1) to UTC."""
+    """Convert TAI (in sec from midnight 1958 Jan 1) to UTC.
+
+    Parameters
+    ----------
+    tai : int or float
+        Time in International Atomic Time (TAI), which is defined as the number
+        of seconds after 1958-01-01 00:00 (NOT including leap seconds)
+
+    Returns
+    -------
+    utc : str
+        Date string of the form YYYY-MM-DDTHH:MM:SS
+    """
+    # Validate input
+    if not isinstance(tai, (int,float)):
+        print(f'ERROR: {tai} is not a valid TAI int or float!', sys.stderr)
+        raise ValueError
+    
     date_tai = Time(tai-epoch_diff-19.0, format='gps', scale='tai')
     d = Time(date_tai, format='isot', scale='utc')
     return d.isot
@@ -17,10 +35,42 @@ def tai2utc(tai):
 def utc2tai(utc):
     """Convert UTC to TAI (in sec from midnight 1958 Jan 1).
 
-    UTC is a string of the form YYYY-MMM-DDTHH:MM:SS. Other forms
-    should also work as the date parser is pretty good.
+    Parameters
+    ----------
+    utc : str
+        Date string of the form YYYY-MM-DDTHH:MM:SS. Other formats
+        are also accepted, since the date parser is extremely flexible,
+        however some odd inputs may have unexpected results (e.g. "May 4"
+        will be parsed as {CURRENT YEAR}-05-04)
+
+    Returns
+    -------
+    tai : float
+        Time in International Atomic Time (TAI), which is defined as the number
+        of seconds after 1958-01-01 00:00 (NOT including leap seconds)
     """
-    date = parse(utc)
+    # Validate input and remove extra whitespace
+    if not isinstance(utc, str):
+        print(f'ERROR: {utc} is not a valid time string!', sys.stderr)
+        raise ValueError
+    else:
+        input_utc = utc.strip()
+    
+    # Set the default datetime used for filling in missing data
+    default_datetime = datetime(datetime.now().year, 1, 1, 0, 0, 0)
+
+    # Fix short strings not normally caught by the parser
+    if any(c.isalpha() for c in input_utc):
+        # Skip any string containing letters (e.g. 2015-May-04, feb29)
+        pass
+    elif len(input_utc) == 6 and input_utc.isdecimal():
+        # Fix YYYYMM
+        input_utc = input_utc + '01' # now YYYYMM01
+    elif len(input_utc) <= 7 and '.' in input_utc:
+        # Fix YYYY.MM or MM.YYYY
+        input_utc = input_utc.replace('.', '-')
+
+    date = parse(input_utc, default=default_datetime)
     date_string = date.strftime('%Y-%m-%dT%H:%M:%S.%f')
     date_utc = Time(date_string, format='isot', scale='utc')
     tai = date_utc.gps + epoch_diff + 19.0


### PR DESCRIPTION
Some minor bugfixes and quality-of-life improvements:

* Improved searching and handling of the EIS as-run catalog
   - Inverted default search pattern (new order: input_dir -> current dir -> home -> SSW)
   - Will also check for write permissions, which are needed for updating the catalog and adding an extra search index
* Improved reliability and flexibility of time format parsing used in the `eis_catalog` GUI and `eispac.db.EISAsRun`
   - Can now input a relative "end date" that specifies the number of days before or after the start date
   - Added convenience strings of "start" or "launch" for the first date in the catalog and "now", "today", or "end" for the current date.
 * Ensured that the list of templates returned by `eispac.match_templates()` is properly sorted alphabetically on all operating systems