### PR TITLE
Fido client patch and QoL update

### DIFF
--- a/docs/guide/03-download.rst
+++ b/docs/guide/03-download.rst
@@ -9,7 +9,11 @@ eis_catalog GUI or Web Browser
 The easiest way to search for and download the processed HDF5 files is to
 use the  ``eis_catalog`` GUI tool included with EISPAC. This tool provides
 an easy interface to the official EIS as-run database and can search based on
-a wide range of technical criteria (see the :ref:`sec-catalog` section for details).
+a wide range of criteria (see the :ref:`sec-catalog` section for details).
+After searching, you can also view the metadata and wavelength lists for each
+observation as well as a context image showing the EIS field-of-view on a SDO/AIA 
+or SOHO/EIT image (depnding on which was avialable at the time).
+
 Alternatively, you can browse and download files directly from the online archive
 (https://eis.nrl.navy.mil/) or use the `~eispac.db.download_hdf5_data()`
 function (assuming you know the exact name of the file you want).
@@ -20,25 +24,35 @@ Using SunPy's Fido Interface
 As of November of 2022, there is now a handy client for Sunpy's ``Fido`` data
 interface! `~sumpy.net.Fido` is a unified tool that can query a variety of
 solar and heliophysics data repositories and return a standardized format of
-results for downloading. A general guide for using `~sumpy.net.Fido can be found
-in the `Finding and Downloading Data <https://docs.sunpy.org/en/latest/guide/acquiring_data/fido.html#fido-guide>`_
+results for downloading. A general guide for using `~sumpy.net.Fido`` can be found
+in the `Acquiring Data <https://docs.sunpy.org/en/stable/tutorial/acquiring_data/index.html>`_
 section of the SunPy User's Guide.
 
+By default, the client for EIS data only returns entries for the data.h5 files
+and fetching a data.h5 file will automatically download the matching head.h5
+file. The original level-1 FITS files are also available, should a user wish to 
+analyze the data using older IDL routines. Fetching a FITS entry will download 
+both the "l1" (data) and "er" (errors) files produced by the "EIS_PREP" 
+routine in SolarSoft/IDL (Note: these FITS files contain exactly the same data 
+as the HDF5 files, but are missing some of the metadata which are computed by 
+SSW routines).
+
+European users may get better download speeds from the data mirror hosted by
+the Mullard Space Science Laboratory (MSSL) in the UK. To use it, set 
+``a.Provider(MSSL)``
+
 Here is a simple example for initializing and using the EISPAC Fido interface.
-**Please note:** At this time, only time-based searches of EIS data are available
-through ``Fido``.
+**Important note:** At this time, only time-based searches of EIS data are available
+through ``Fido``. For more complex searches, please use the ``eis_catalog`` GUI.
 
 .. code:: python
 
    >>> from sunpy.net import Fido, attrs as a
    >>> import eispac.net
-   >>> from eispac.net.attrs import FileType
    >>> results = Fido.search(a.Time('2020-11-09 00:00:00','2020-11-09 01:00:00'),
    ...                       a.Instrument('EIS'),
-   ...                       a.Physobs.intensity,
    ...                       a.Source('Hinode'),
-   ...                       a.Provider('NRL'),
-   ...                       a.Level('1'))  #doctest: +REMOTE_DATA
+   ...                       a.Provider('NRL'))  #doctest: +REMOTE_DATA
    >>> results  #doctest: +REMOTE_DATA
    <sunpy.net.fido_factory.UnifiedResponse object at ...>
    Results from 1 Provider:
@@ -49,17 +63,13 @@ through ``Fido``.
           Start Time               End Time        ... Level   FileType
    ----------------------- ----------------------- ... ----- -----------
    2020-11-09 00:10:12.000 2020-11-09 00:10:12.999 ...     1   HDF5 data
-   2020-11-09 00:10:12.000 2020-11-09 00:10:12.999 ...     1 HDF5 header
-   2020-11-09 00:10:12.000 2020-11-09 00:10:12.999 ...     1        FITS
    <BLANKLINE>
    <BLANKLINE>
    >>> results = Fido.search(a.Time('2020-11-09 00:00:00','2020-11-09 01:00:00'),
    ...                       a.Instrument('EIS'),
-   ...                       a.Physobs.intensity,
    ...                       a.Source('Hinode'),
    ...                       a.Provider('NRL'),
-   ...                       a.Level('1'),
-   ...                       FileType('HDF5 header'))  #doctest: +REMOTE_DATA
+   ...                       a.eispac.FileType('Any'))  #doctest: +REMOTE_DATA
    >>> results  #doctest: +REMOTE_DATA
    <sunpy.net.fido_factory.UnifiedResponse object at ...>
    Results from 1 Provider:
@@ -69,7 +79,9 @@ through ``Fido``.
    <BLANKLINE>
           Start Time               End Time        ... Level   FileType
    ----------------------- ----------------------- ... ----- -----------
+   2020-11-09 00:10:12.000 2020-11-09 00:10:12.999 ...     1   HDF5 data
    2020-11-09 00:10:12.000 2020-11-09 00:10:12.999 ...     1 HDF5 header
+   2020-11-09 00:10:12.000 2020-11-09 00:10:12.999 ...     1        FITS
 
 .. Attention::
    Some laboratory and institution networks (including VPNs) are known to cause

--- a/eispac/net/attrs.py
+++ b/eispac/net/attrs.py
@@ -10,19 +10,27 @@ class FileType(SimpleAttr):
     Parameters
     ----------
     value: `str`
-        Possible values are "HDF5 data" or "HDF5 header" to retrieve the 
-        data and header files, respectively, in HDF5 format, or "FITS" to
-        retrieve the FITS files. Inputs are not case sensitive.
+        Select from "HDF5" or "HDF5 data" to retrieve both the data and header 
+        files in HDF5 format, "HDF5 header" for ONLY the headers, "FITS" for
+        for both the "l1" and "er" FITS files, or "ANY" to retrieve all
+        file types available. Inputs are not case sensitive.
     """
     
     def __init__(self, value):
         if not isinstance(value, str):
             raise ValueError('File type must be a string')
-        value = value.lower()
+        value = value.lower().strip()
         if 'hdf5' in value:
-            value = '.'.join([value[5:], 'h5'])
+            if len(value) > 4:
+                value = '.'.join([value[5:], 'h5'])
+            else:
+                # Selecting just 'HDF5' will search/download 'data.h5' files
+                value = 'data.h5'
         if value == 'header.h5':
             value = 'head.h5'
-        if value not in ['data.h5', 'head.h5', 'fits']:
-            raise ValueError(f'File type {value} must be either "HDF5 data", "HDF5 header", or "FITS".')
+        if value == 'all':
+            value = 'any'
+        if value not in ['data.h5', 'head.h5', 'fits', 'any']:
+            raise ValueError(f'File type {value} must be either "HDF5",'
+                            +f' "HDF5 data", "HDF5 header", "FITS", or "ANY".')
         super().__init__(value)

--- a/eispac/net/client.py
+++ b/eispac/net/client.py
@@ -1,30 +1,60 @@
+__all__ = ['EISClient']
+
+import copy
+from pathlib import Path
+import numpy as np
+from sunpy import __version__ as sunpy_ver
 from sunpy.net import attrs as a
+from sunpy.net.attr import SimpleAttr
 from sunpy.net.dataretriever import GenericClient, QueryResponse
+from sunpy.net.base_client import QueryResponseRow
 from sunpy.net.scraper import Scraper
 from sunpy.time import TimeRange
+from sunpy.util.parfive_helpers import Downloader
 
 from eispac.net.attrs import FileType
 
-__all__ = ['EISClient']
-
-
 class EISClient(GenericClient):
-    """
-    Provides access to the level 1 EIS data in HDF5 and FITS format.
+    """Provides access to the level 1 EIS data in HDF5 and FITS format.
 
-    This data is hosted by the `Naval Research Laboratory <https://eis.nrl.navy.mil/>`__.
+    The EIS level-1 HDF5 files come in pairs of "data.h5" and "head.h5" files
+    containing, respectively, the EUV spectra and header/metadata for a single
+    observation. By default, this client only returns entries for the data files
+    and fetching a data.h5 file will automatically download the matching header.
+    The original level-1 FITS files are also available, should a user wish to 
+    analyze the data using older IDL routines. Fetching a FITS entry will download 
+    both the "l1" (data) and "er" (errors) files produced by the "EIS_PREP" 
+    routine in SolarSoft/IDL.
+
+    This data is processed and hosted by the U.S. Naval Research Laboratory (NRL)
+    A mirror of the HDF5 files is hosted by the Mullard Space Science Laboratory
+    (MSSL) in the UK.
 
     Examples
     --------
     >>> from sunpy.net import Fido, attrs as a
     >>> import eispac.net
-    >>> from eispac.net.attrs import FileType
     >>> results = Fido.search(a.Time('2020-11-09 00:00:00','2020-11-09 01:00:00'),
     ...                       a.Instrument('EIS'),
-    ...                       a.Physobs.intensity,
+    ...                       a.Source('Hinode'),
+    ...                       a.Provider('NRL'))  #doctest: +SKIP
+    >>> results  #doctest: +SKIP
+    <sunpy.net.fido_factory.UnifiedResponse object at ...>
+    Results from 1 Provider:
+    <BLANKLINE>
+    1 Results from the EISClient:
+    Source: https://eis.nrl.navy.mil/
+    <BLANKLINE>
+           Start Time               End Time        ... Level   FileType
+    ----------------------- ----------------------- ... ----- -----------
+    2020-11-09 00:10:12.000 2020-11-09 00:10:12.999 ...     1   HDF5 data
+    <BLANKLINE>
+    <BLANKLINE>
+    >>> results = Fido.search(a.Time('2020-11-09 00:00:00','2020-11-09 01:00:00'),
+    ...                       a.Instrument('EIS'),
     ...                       a.Source('Hinode'),
     ...                       a.Provider('NRL'),
-    ...                       a.Level('1'))  #doctest: +SKIP
+    ...                       a.eispac.FileType('Any'))  #doctest: +SKIP
     >>> results  #doctest: +SKIP
     <sunpy.net.fido_factory.UnifiedResponse object at ...>
     Results from 1 Provider:
@@ -39,58 +69,169 @@ class EISClient(GenericClient):
     2020-11-09 00:10:12.000 2020-11-09 00:10:12.999 ...     1        FITS
     <BLANKLINE>
     <BLANKLINE>
-    >>> results = Fido.search(a.Time('2020-11-09 00:00:00','2020-11-09 01:00:00'),
-    ...                       a.Instrument('EIS'),
-    ...                       a.Physobs.intensity,
-    ...                       a.Source('Hinode'),
-    ...                       a.Provider('NRL'),
-    ...                       a.Level('1'),
-    ...                       FileType('HDF5 header'))  #doctest: +SKIP
-    >>> results  #doctest: +SKIP
-    <sunpy.net.fido_factory.UnifiedResponse object at ...>
-    Results from 1 Provider:
-    <BLANKLINE>
-    1 Results from the EISClient:
-    Source: https://eis.nrl.navy.mil/
-    <BLANKLINE>
-           Start Time               End Time        ... Level   FileType
-    ----------------------- ----------------------- ... ----- -----------
-    2020-11-09 00:10:12.000 2020-11-09 00:10:12.999 ...     1 HDF5 header
-    <BLANKLINE>
-    <BLANKLINE>
     """
-    baseurl_hdf5 = r'https://eis.nrl.navy.mil/level1/hdf5/%Y/%m/%d/eis_%Y%m%d_%H%M%S.(\w){4}.h5'
+
+    current_provider = 'nrl'
+    nrl_topurl = r'https://eis.nrl.navy.mil/level1/'
+    mssl_topurl = r'https://vsolar.mssl.ucl.ac.uk/eispac/'
+    baseurl_hdf5 = r'hdf5/%Y/%m/%d/eis_%Y%m%d_%H%M%S.(\w){4}.h5'
     pattern_hdf5 = '{}/{year:4d}/{month:2d}/{day:2d}/eis_{:8d}_{hour:2d}{minute:2d}{second:2d}.{FileType}'
-    baseurl_fits = r'https://eis.nrl.navy.mil/level1/fits/%Y/%m/%d/eis_er_%Y%m%d_%H%M%S.fits'
-    pattern_fits = '{}/{year:4d}/{month:2d}/{day:2d}/eis_er_{:8d}_{hour:2d}{minute:2d}{second:2d}.{FileType}'
+    format_hdf5 = r'hdf5/{{year:4d}}/{{month:2d}}/{{day:2d}}/'+ \
+                  r'eis_{{:8d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}.{{FileType}}'
+    baseurl_fits = r'fits/%Y/%m/%d/eis_l1_%Y%m%d_%H%M%S.fits'
+    pattern_fits = '{}/{year:4d}/{month:2d}/{day:2d}/eis_l1_{:8d}_{hour:2d}{minute:2d}{second:2d}.{FileType}'
+    format_fits = r'fits/{{year:4d}}/{{month:2d}}/{{day:2d}}/'+ \
+                  r'eis_l1_{{:8d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}.{{FileType}}'
 
     @property
     def info_url(self):
-        return 'https://eis.nrl.navy.mil/'
+        if self.current_provider.lower() == 'nrl':
+            return 'https://eis.nrl.navy.mil/'
+        if self.current_provider.lower() == 'mssl':
+            return 'https://vsolar.mssl.ucl.ac.uk/eispac/hdf5/'
 
     def search(self, *args, **kwargs):
-        # NOTE: Search is overridden because URL and pattern depending on the filetype.
+        # NOTE: Search is overridden because URL and pattern depend on filetype.
         # This enables multiple filetypes to be returned in the same query.
         metalist = []
         matchdict = self._get_match_dict(*args, **kwargs)
+        t_range = TimeRange(matchdict['Start Time'], matchdict['End Time'])
         all_filetypes = matchdict.get('FileType')
-        for ft in all_filetypes:
-            if 'h5' in ft:
-                baseurl = self.baseurl_hdf5
-                pattern = self.pattern_hdf5
-            else:
-                baseurl = self.baseurl_fits
-                pattern = self.pattern_fits
+        if len(all_filetypes) > 1:
+            # When FileType is NOT specified, default to 'data.h5' (first index)
+            all_filetypes = [all_filetypes[0]]
+        if all_filetypes[0].lower() == 'any':
+            all_filetypes = ['data.h5', 'head.h5', 'fits']
+        matchdict['FileType'] = all_filetypes # copy changes back to matchdict
+        for f_type in all_filetypes:
+            if matchdict.get('Provider')[0].lower() == 'nrl':
+                self.current_provider = 'nrl'
+                topurl = self.nrl_topurl
+            elif matchdict.get('Provider')[0].lower() == 'mssl':
+                self.current_provider = 'mssl'
+                if 'fits' in f_type:
+                    print('NOTICE: level-1 FITS files are only available from NRL')
+                    continue
+                else:
+                    topurl = self.mssl_topurl
 
-            scraper = Scraper(baseurl, regex=True)
-            tr = TimeRange(matchdict['Start Time'], matchdict['End Time'])
-            filesmeta = scraper._extract_files_meta(tr, extractor=pattern, matcher={'FileType': ft})
+            if 'h5' in f_type:
+                baseurl = topurl + self.baseurl_hdf5
+                pattern = self.pattern_hdf5
+                parse_format = topurl + self.format_hdf5
+            elif 'fits' in f_type:
+                baseurl = topurl + self.baseurl_fits
+                pattern = self.pattern_fits
+                parse_format = topurl + self.format_fits
+            else:
+                continue # skip unknown filetypes
+
+            if sunpy_ver < '6.1':
+                # Old regex Scraper
+                scraper = Scraper(baseurl, regex=True)
+                filesmeta = scraper._extract_files_meta(t_range, extractor=pattern, 
+                                                        matcher={'FileType': f_type})
+            else:
+                # New parse Scraper (added in SunPy 6.1 on 2025-02-24)
+                scraper = Scraper(format=parse_format)
+                filesmeta = scraper._extract_files_meta(t_range, 
+                                                        matcher={'FileType': f_type})
             filesmeta = sorted(filesmeta, key=lambda k: k['url'])
             for i in filesmeta:
                 rowdict = self.post_search_hook(i, matchdict)
                 metalist.append(rowdict)
 
-        return QueryResponse(metalist, client=self)
+        if len(metalist) > 0:
+            return QueryResponse(metalist, client=self)
+        else:
+            return QueryResponse(None, client=self)
+    
+    def fetch(self, qres, path=None, overwrite=False,
+              progress=True, downloader=None, wait=True, **kwargs):
+        """
+        Download a set of results.
+
+        Parameters
+        ----------
+        qres : `~sunpy.net.dataretriever.QueryResponse`
+            Results to download.
+        path : `str` or `pathlib.Path`, optional
+            Path to the download directory, or file template including the
+            ``{file}`` string which will be replaced with the filename.
+        overwrite : `bool` or `str`, optional
+            Determine how to handle downloading if a file already exists with the
+            same name. If `False` the file download will be skipped and the path
+            returned to the existing file, if `True` the file will be downloaded
+            and the existing file will be overwritten, if ``'unique'`` the filename
+            will be modified to be unique.
+        progress : `bool`, optional
+            If `True` show a progress bar showing how many of the total files
+            have been downloaded. If `False`, no progress bar will be shown.
+        downloader : `parfive.Downloader`, optional
+            The download manager to use.
+        wait : `bool`, optional
+            If `False` ``downloader.download()`` will not be called. Only has
+            any effect if ``downloader`` is not `None`.
+
+        Returns
+        -------
+        `parfive.Results`
+        """
+        # NOTE: fetch is overwritten since we often need to download pairs of
+        #       files for a single obs (data.h5 & head.h5 or l1 & er FITS) 
+
+        if path is not None:
+            path = Path(path)
+
+        if isinstance(qres, QueryResponseRow):
+            qres = qres.as_table()
+
+        urls = []
+        if len(qres):
+            urls = list(qres['url'])
+
+        filenames = [url.split('/')[-1] for url in urls]
+
+        paths = self._get_full_filenames(qres, filenames, path)
+
+        # If downloading data.h5 files, always download the head.h5 files too
+        data_h5_in_list = any(['data.h5' in NAME for NAME in filenames])
+        head_h5_in_list = any(['head.h5' in NAME for NAME in filenames])
+        if data_h5_in_list and not head_h5_in_list:
+            # Add missing head.h5 files to the list
+            urls, paths = self._add_missing_file_pairs(urls, paths, 'data.h5', 'head.h5')
+
+        # If downloading FITS files, always download both the l1 and er files
+        fits_in_list = any(['eis_l1_' in NAME for NAME in filenames])
+        if fits_in_list:
+            # Add missing "eis_er_*.fits" files to the list
+            urls, paths = self._add_missing_file_pairs(urls, paths, 'eis_l1_', 'eis_er_')
+        
+        dl_set = True
+        if not downloader:
+            dl_set = False
+            downloader = Downloader(progress=progress, overwrite=overwrite)
+
+        for url, filename in zip(urls, paths):
+            downloader.enqueue_file(url, filename=filename, **self.enqueue_file_kwargs)
+
+        if dl_set and not wait:
+            return
+
+        return downloader.download()
+
+    def _add_missing_file_pairs(self, urls, paths, find_str, replace_str):
+        # Appending to and sorting file lists to include missing pairs 
+        new_urls = copy.deepcopy(urls)
+        new_paths = copy.deepcopy(paths)
+        for i in range(len(urls)):
+            new_urls.append(np.str_(urls[i].replace(find_str, replace_str)))
+            new_paths.append(Path(str(paths[i]).replace(find_str, replace_str)))
+
+        urls = sorted(new_urls)
+        paths = sorted(new_paths)
+
+        return urls, paths
 
     def post_search_hook(self, i, matchdict):
         # This makes the final display names of the file types nicer
@@ -109,13 +250,15 @@ class EISClient(GenericClient):
             a.Instrument: [('EIS', 'Extreme Ultraviolet Imaging Spectrometer')],
             a.Physobs: [('intensity', 'Spectrally resolved intensity in detector units')],
             a.Source: [('Hinode', 'The Hinode mission is a partnership between JAXA, NASA, and UKSA')],
-            a.Provider: [('NRL', 'U.S. Naval Research Laboratory')],
+            a.Provider: [('NRL', 'U.S. Naval Research Laboratory'),
+                         ('MSSL', 'Mullard Space Science Laboratory (UK)')],
             a.Level: [
-                ('1', 'EIS: The EIS client can only return level 1 data. Level 0 EIS data is available from the VSO.')
+                ('1', 'EIS: processed data with corrected metadata. Use the VSO for Level-0 data.')
             ],
-            FileType: [('data.h5', 'These files contain the actual intensity data in HDF5 format.'),
-                       ('head.h5', 'These files contain only the header metadata in HDF5 format.'),
-                       ('fits', 'These files contain both data and metadata in FITS format')],
+            FileType: [('data.h5', 'Level-1 EUV spectra in HDF5 format'),
+                       ('head.h5', 'Level-1 header & metadata in HDF5 format'),
+                       ('fits', 'Pairs of "l1" and "er" files in FITS format'),
+                       ('any', 'Retrieve any/all file types available')],
         }
 
     @classmethod
@@ -134,4 +277,17 @@ class EISClient(GenericClient):
         """
         required = {a.Time, a.Instrument, a.Source}
         optional = {a.Provider, a.Physobs, a.Level, FileType}
-        return cls.check_attr_types_in_query(query, required, optional)
+        
+        # Check that all query attrs are accepted by this client
+        if not cls.check_attr_types_in_query(query, required, optional):
+            return False
+
+        # Validate the actual attribute values
+        regattrs_dict = cls.register_values()
+        for key in regattrs_dict:
+            all_vals = [i[0].lower() for i in regattrs_dict[key]]
+            for x in query:
+                if (isinstance(x, key) and issubclass(key, SimpleAttr) 
+                and str(x.value).lower() not in all_vals):
+                    return False
+        return True

--- a/eispac/net/tests/test_eis_client.py
+++ b/eispac/net/tests/test_eis_client.py
@@ -1,7 +1,22 @@
+import urllib
 import pytest
 from sunpy.net import Fido, attrs as a
 import eispac.net
 
+# Check status of remote servers so we know when to skip the tests
+try:
+    with urllib.request.urlopen('https://eis.nrl.navy.mil/level1/') as nrl_site:
+        nrl_status = nrl_site.status
+except:
+    nrl_status = -1
+nrl_unavailable = nrl_status < 200 or nrl_status >= 300
+
+try:
+    with urllib.request.urlopen('https://vsolar.mssl.ucl.ac.uk/eispac/hdf5/') as mssl_site:
+        mssl_status = nrl_site.status
+except:
+    mssl_status = -1
+mssl_unavailable = mssl_status < 200 or mssl_status >= 300
 
 @pytest.fixture
 def eis_query():
@@ -13,35 +28,32 @@ def eis_query():
     level = a.Level('1')
     return time, instr, obs, source, provider, level
 
-# @pytest.mark.skip(reason="NRL server maintenance")
-@pytest.mark.skip(reason="SSL or Fido issues")
-# @pytest.mark.remote_data
-def test_search_all_types(eis_query):
+def test_registered_attrs():
+    attr_names = ['data_h5', 'head_h5', 'fits', 'any']
+    for an in attr_names:
+        assert hasattr(a.eispac.FileType, an)
+
+@pytest.mark.skipif(nrl_unavailable, reason="NRL server issues")
+def test_search_default(eis_query):
     q = Fido.search(*eis_query)
+    assert len(q) == 1
+    assert len(q[0]) == 1
+    assert q[0,0]['url'] == 'https://eis.nrl.navy.mil/level1/hdf5/2022/03/29/eis_20220329_222113.data.h5'
+
+@pytest.mark.skipif(nrl_unavailable, reason="NRL server issues")
+def test_search_all_types(eis_query):
+    q = Fido.search(*eis_query, a.eispac.FileType('Any'))
     assert len(q) == 1
     assert len(q[0]) == 3
     assert q[0,0]['url'] == 'https://eis.nrl.navy.mil/level1/hdf5/2022/03/29/eis_20220329_222113.data.h5'
 
-# @pytest.mark.skip(reason="NRL server maintenance")
-@pytest.mark.skip(reason="SSL or Fido issues")
-# @pytest.mark.remote_data
-def test_search_fits_only(eis_query):
-    q = Fido.search(*eis_query, a.eispac.FileType('FITS'))
-    assert len(q) == 1
-    assert len(q[0]) == 1
-    assert q[0,0]['url'] == 'https://eis.nrl.navy.mil/level1/fits/2022/03/29/eis_er_20220329_222113.fits'
-
-# @pytest.mark.skip(reason="NRL server maintenance")
-# @pytest.mark.skip(reason="SSL or Fido issues")
 @pytest.mark.parametrize('file_type, file_url', [
-    ('FITS', 'https://eis.nrl.navy.mil/level1/fits/2022/03/29/eis_er_20220329_222113.fits'),
+    ('FITS', 'https://eis.nrl.navy.mil/level1/fits/2022/03/29/eis_l1_20220329_222113.fits'),
     ('HDF5 data', 'https://eis.nrl.navy.mil/level1/hdf5/2022/03/29/eis_20220329_222113.data.h5'),
     ('HDF5 header', 'https://eis.nrl.navy.mil/level1/hdf5/2022/03/29/eis_20220329_222113.head.h5')
 ])
 
-# @pytest.mark.skip(reason="NRL server maintenance")
-@pytest.mark.skip(reason="SSL or Fido issues")
-# @pytest.mark.remote_data
+@pytest.mark.skipif(nrl_unavailable, reason="NRL server issues")
 def test_search_individual_filetypes(eis_query, file_type, file_url):
     q = Fido.search(*eis_query, a.eispac.FileType(file_type))
     assert len(q) == 1
@@ -49,9 +61,7 @@ def test_search_individual_filetypes(eis_query, file_type, file_url):
     assert q[0,0]['url'] == file_url
     assert q[0,0]['FileType'] == file_type
 
-# @pytest.mark.skip(reason="NRL server maintenance")
-@pytest.mark.skip(reason="SSL or Fido issues")
-# @pytest.mark.remote_data
+@pytest.mark.skipif(nrl_unavailable, reason="NRL server issues")
 def test_combined_hdf5_search(eis_query):
     q = Fido.search(*eis_query,
                     a.eispac.FileType('HDF5 data') | a.eispac.FileType('HDF5 header'))
@@ -61,8 +71,9 @@ def test_combined_hdf5_search(eis_query):
     assert q[0,0]['FileType'] == 'HDF5 data'
     assert q[1,0]['FileType'] == 'HDF5 header'
 
-
-def test_registered_attrs():
-    attr_names = ['fits', 'data_h5', 'head_h5']
-    for an in attr_names:
-        assert hasattr(a.eispac.FileType, an)
+@pytest.mark.skipif(mssl_unavailable, reason="MSSL server issues")
+def test_search_mssl(eis_query):
+    q = Fido.search(*eis_query[:4], a.Provider('MSSL'))
+    assert len(q) == 1
+    assert len(q[0]) == 1
+    assert q[0,0]['url'] == 'https://vsolar.mssl.ucl.ac.uk/eispac/hdf5/2022/03/29/eis_20220329_222113.data.h5'


### PR DESCRIPTION
# Summary of Changes

Patched some issues with the `EISClient` for SunPy's Fido and added a few quality-of-life improvements. Closes #120

* Updated the search patterns to use the new parse-format added in SunPy v6.1 (following [this](<https://docs.sunpy.org/en/latest/topic_guide/scraper_migration.html>) migration guide).
* Patched an issue with the client returning results when a different instrument is queried.
* Added the "MSSL" data mirror for HDF5 files as an additional Provider. This should give better download speeds for European users.
* Reenabled tests of the EISClient and added an automatic check for server issues (so the tests can be skipped as needed)
* Updated the default behavior for a faster and smoother user experience (see below for details). 
* Updated doc strings and user guide

# Updated EISClient Behavior

By default, the client only returns entries for the HDF5 data files and fetching a `data.h5` file will automatically download the matching `head.h5` too. This change cuts the overall search time by 50 - 60%, eliminates duplicate entries, and ensures that users always download the files they need. Searching for and fetching `head.h5` files will only return and download the header files, should a user need or wish to do so. The old behavior of retuning a list of all files associated with each observation can produced by setting the `a.eispac.FileType("any")` search parameter.

In general, the FITS files are really only useful to IDL users who wish to analyze the data using older IDL routines, since they contain the exact same data as the HDF5 files, but are missing some of the essential metadata that must be provided by the SSW routines. To our knowledge, no one was using the Fido client to download the FITS files. This is evidenced by the fact that the FITS level-1 data comes in pairs of "l1" (data) and "er" (errors) files generated by the "EIS_PREP" routine in SolarSoft/IDL and the old EISClient was actually only searching for and downloading the "er" files (a problem no one has mentioned or raised before). This issue has also been patched. Now, fetching a FITS entry will download both the "l1" and "er" files.

